### PR TITLE
Add ability to detach and re-attach the controller

### DIFF
--- a/lib/LocalEchoController.js
+++ b/lib/LocalEchoController.js
@@ -24,8 +24,9 @@ import {
 export default class LocalEchoController {
   constructor(term, options = {}) {
     this.term = term;
-    this.term.on("data", this.handleTermData.bind(this));
-    this.term.on("resize", this.handleTermResize.bind(this));
+    this._handleTermData = this.handleTermData.bind(this);
+    this._handleTermResize = this.handleTermResize.bind(this)
+    
     this.history = new HistoryController(options.historySize || 10);
     this.maxAutocompleteEntries = options.maxAutocompleteEntries || 100;
 
@@ -39,11 +40,29 @@ export default class LocalEchoController {
       cols: this.term.cols,
       rows: this.term.rows
     };
+    
+    this.attach()
   }
 
   /////////////////////////////////////////////////////////////////////////////
   // User-Facing API
   /////////////////////////////////////////////////////////////////////////////
+  
+  /**
+   *  Detach the controller from the terminal
+   */
+  detach() {
+    this.term.off("data", this._handleTermData);
+    this.term.off("resize", this._handleTermResize);
+  }
+  
+  /**
+   * Attach controller to the terminal, handling events
+   */
+  attach() {
+    this.term.on("data", this._handleTermData);
+    this.term.on("resize", this._handleTermResize);
+  }
 
   /**
    * Register a handler that will be called to satisfy auto-completion


### PR DESCRIPTION
I have a use case where I'll need to dynamically detach the controller every now and then to give control to another controller.

This makes it easy for users to detach and reattach the controller on the Terminal on the fly.