### PR TITLE
Update to work with xtermjs 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ The local echo controller tries to replicate most of the bash-like user experien
     const term = new Terminal();
     term.open(document.getElementById('terminal'));
 
-    // Create a local echo controller
+    // Create a local echo controller (xterm.js v3)
     const localEcho = new LocalEchoController(term);
+    // Create a local echo controller (xterm.js >=v4)
+    const localEcho = new LocalEchoController();
+    term.loadAddon(localEcho);
 
     // Read a single line from the user
     localEcho.read("~$ ")
@@ -68,8 +71,11 @@ The local echo controller tries to replicate most of the bash-like user experien
     const term = new Terminal();
     term.open(document.getElementById('terminal'));
 
-    // Create a local echo controller
+    // Create a local echo controller (xterm.js v3)
     const localEcho = new LocalEchoController(term);
+    // Create a local echo controller (xterm.js >=v4)
+    const localEcho = new LocalEchoController();
+    term.loadAddon(localEcho);
 
     // Read a single line from the user
     localEcho.read("~$ ")

--- a/lib/LocalEchoController.js
+++ b/lib/LocalEchoController.js
@@ -22,7 +22,7 @@ import {
  * - Auto-complete hooks
  */
 export default class LocalEchoController {
-  constructor(term, options = {}) {
+  constructor(term = null, options = {}) {
     this.term = term;
     this._handleTermData = this.handleTermData.bind(this);
     this._handleTermResize = this.handleTermResize.bind(this)
@@ -36,12 +36,17 @@ export default class LocalEchoController {
     this._cursor = 0;
     this._activePrompt = null;
     this._activeCharPrompt = null;
-    this._termSize = {
-      cols: this.term.cols,
-      rows: this.term.rows
-    };
     
-    this.attach()
+    if (term) this.attach();
+  }
+
+  activate(term) {
+    this.term = term;
+    this.attach();
+  }
+
+  dispose() {
+    this.detach();
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -52,16 +57,20 @@ export default class LocalEchoController {
    *  Detach the controller from the terminal
    */
   detach() {
-    this.term.off("data", this._handleTermData);
-    this.term.off("resize", this._handleTermResize);
+    this._onDataListener.dispose();
+    this._onResizeListener.dispose();
   }
   
   /**
    * Attach controller to the terminal, handling events
    */
   attach() {
-    this.term.on("data", this._handleTermData);
-    this.term.on("resize", this._handleTermResize);
+    this._onDataListener = this.term.onData(this._handleTermData);
+    this._onResizeListener = this.term.onResize(this._handleTermResize);
+    this._termSize = {
+      cols: this.term.cols,
+      rows: this.term.rows,
+    };
   }
 
   /**

--- a/lib/LocalEchoController.js
+++ b/lib/LocalEchoController.js
@@ -36,10 +36,17 @@ export default class LocalEchoController {
     this._cursor = 0;
     this._activePrompt = null;
     this._activeCharPrompt = null;
+    this._termSize = {
+      cols: 0,
+      rows: 0,
+    };
 
     this._disposables = [];
     
-    if (term) this.attach();
+    if (term) {
+      if (term.loadAddon) term.loadAddon(this);
+      else this.attach();
+    }
   }
 
   // xterm.js new plugin API:
@@ -59,16 +66,26 @@ export default class LocalEchoController {
    *  Detach the controller from the terminal
    */
   detach() {
-    this._disposables.forEach(d => d.dispose());
-    this._disposables = [];
+    if (this.term.off) {
+      this.term.off("data", this._handleTermData);
+      this.term.off("resize", this._handleTermResize);
+    } else {
+      this._disposables.forEach(d => d.dispose());
+      this._disposables = [];
+    }
   }
   
   /**
    * Attach controller to the terminal, handling events
    */
   attach() {
-    this._disposables.push(this.term.onData(this._handleTermData));
-    this._disposables.push(this.term.onResize(this._handleTermResize));
+    if (this.term.on) {
+      this.term.on("data", this._handleTermData);
+      this.term.on("resize", this._handleTermResize);
+    } else {
+      this._disposables.push(this.term.onData(this._handleTermData));
+      this._disposables.push(this.term.onResize(this._handleTermResize));
+    }
     this._termSize = {
       cols: this.term.cols,
       rows: this.term.rows,

--- a/lib/LocalEchoController.js
+++ b/lib/LocalEchoController.js
@@ -36,15 +36,17 @@ export default class LocalEchoController {
     this._cursor = 0;
     this._activePrompt = null;
     this._activeCharPrompt = null;
+
+    this._disposables = [];
     
     if (term) this.attach();
   }
 
+  // xterm.js new plugin API:
   activate(term) {
     this.term = term;
     this.attach();
   }
-
   dispose() {
     this.detach();
   }
@@ -57,16 +59,16 @@ export default class LocalEchoController {
    *  Detach the controller from the terminal
    */
   detach() {
-    this._onDataListener.dispose();
-    this._onResizeListener.dispose();
+    this._disposables.forEach(d => d.dispose());
+    this._disposables = [];
   }
   
   /**
    * Attach controller to the terminal, handling events
    */
   attach() {
-    this._onDataListener = this.term.onData(this._handleTermData);
-    this._onResizeListener = this.term.onResize(this._handleTermResize);
+    this._disposables.push(this.term.onData(this._handleTermData));
+    this._disposables.push(this.term.onResize(this._handleTermResize));
     this._termSize = {
       cols: this.term.cols,
       rows: this.term.rows,


### PR DESCRIPTION
This should still be compatible with xterm v3, though I haven't actually tested it. The `onData` and `onResize` methods have been there for a while ([typescript typings for xtermjs 3.14](https://github.com/xtermjs/xterm.js/blob/release/3.14/typings/xterm.d.ts#L396)), and in theory even [the new addon system](https://xtermjs.org/docs/guides/using-addons/#creating-an-addon) could be used in xtermjs 3.14, though the old way of passing a terminal to the constructor still works.